### PR TITLE
Lower search relevance threshold and sanitize S3 metadata headers

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       query: body.query.trim(),
       userId,
       maxResults: body.limit || 20,
-      minScore: body.minScore || 0.6,
+      minScore: body.minScore || 0.2,
       docIds: body.docIds,
     });
 

--- a/lib/ai/chat.ts
+++ b/lib/ai/chat.ts
@@ -27,7 +27,7 @@ export async function generateChatResponse(context: ChatContext): Promise<ChatRe
       queryEmbedding,
       userId: context.userId,
       maxResults: context.maxResults || 10,
-      minScore: context.minScore || 0.7,
+      minScore: context.minScore || 0.2,
       docIds: context.docIds,
     });
 
@@ -188,7 +188,7 @@ export async function performDocumentSearch({
   query,
   userId,
   maxResults = 20,
-  minScore = 0.6,
+  minScore = 0.2,
   docIds,
 }: {
   query: string;

--- a/lib/storage/s3.ts
+++ b/lib/storage/s3.ts
@@ -63,15 +63,23 @@ export async function uploadFileBuffer(
   // Create a unique key with user and document context
   const key = `${userId}/${docId}/${fileName}`;
 
+  // Sanitize metadata values for HTTP headers - remove control characters and non-ASCII
+  const sanitizeHeaderValue = (value: string): string => {
+    return value
+      .replace(/[\x00-\x1F\x7F-\xFF]/g, '') // Remove control chars and non-ASCII
+      .replace(/[\r\n]/g, '') // Remove line breaks
+      .trim();
+  };
+
   const command = new PutObjectCommand({
     Bucket: bucketName,
     Key: key,
     Body: fileBuffer,
     ContentType: contentType,
     Metadata: {
-      userId,
-      docId,
-      originalName: fileName,
+      userId: sanitizeHeaderValue(userId),
+      docId: sanitizeHeaderValue(docId),
+      originalName: sanitizeHeaderValue(fileName),
       uploadedAt: new Date().toISOString(),
     },
   });


### PR DESCRIPTION
- Reduce minimum similarity score from 0.6-0.7 to 0.2 for broader search results
- Add metadata sanitization in S3 uploads to prevent HTTP header issues