### PR TITLE
Fix duplicate success notifications when deleting documents

### DIFF
--- a/components/documents/DocumentCard.tsx
+++ b/components/documents/DocumentCard.tsx
@@ -82,10 +82,9 @@ export function DocumentCard({
       loadingToastId = showToast.loading(`Deleting "${document.filename}"...`);
       await onDelete(document.docId);
 
-      // Dismiss loading toast
+      // Dismiss loading toast - success notification is handled by parent component
       showToast.dismiss(loadingToastId);
       setShowDeleteDialog(false);
-      showToast.success(`Deleted "${document.filename}"`);
     } catch (error) {
       console.error('Delete error:', error);
       // Dismiss loading toast if it exists


### PR DESCRIPTION
- Remove duplicate success toast from DocumentCard component
- Keep success notification handling in parent dashboard component
- Maintain error notification in DocumentCard for proper error handling
- Ensure loading toast is still properly dismissed in all scenarios
- Prevent double success messages appearing to users